### PR TITLE
Implement TLS certificate configuration (without certmagic)

### DIFF
--- a/config.go
+++ b/config.go
@@ -40,6 +40,11 @@ type configAcmeLe struct {
 	ChallengePort int
 }
 
+type configTLS struct {
+	CertPath string
+	KeyPath  string
+}
+
 type configVHost struct {
 	Domain      string
 	Upstream    string
@@ -64,6 +69,7 @@ type config struct {
 	Domain            string
 	UseSMTPS          bool
 	LetsEncrypt       *configAcmeLe
+	TLS               *configTLS
 	ReadTimeout       time.Duration
 	WriteTimeout      time.Duration
 	MaxMessageBytes   int

--- a/internal/tlsutil/tlsutil.go
+++ b/internal/tlsutil/tlsutil.go
@@ -1,0 +1,60 @@
+package tlsutil
+
+import (
+	"crypto/tls"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type keypairReloader struct {
+	certMu   sync.RWMutex
+	cert     *tls.Certificate
+	certPath string
+	keyPath  string
+}
+
+func NewKeypairReloader(certPath, keyPath string) (*keypairReloader, error) {
+	result := &keypairReloader{
+		certPath: certPath,
+		keyPath:  keyPath,
+	}
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	result.cert = &cert
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGHUP)
+		for range c {
+			log.Printf("Received SIGHUP, reloading TLS certificate and key from %q and %q", certPath, keyPath)
+			if err := result.maybeReload(); err != nil {
+				log.Printf("Keeping old TLS certificate because the new one could not be loaded: %v", err)
+			}
+		}
+	}()
+	return result, nil
+}
+
+func (kpr *keypairReloader) maybeReload() error {
+	newCert, err := tls.LoadX509KeyPair(kpr.certPath, kpr.keyPath)
+	if err != nil {
+		return err
+	}
+	kpr.certMu.Lock()
+	defer kpr.certMu.Unlock()
+	kpr.cert = &newCert
+	return nil
+}
+
+func (kpr *keypairReloader) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		kpr.certMu.RLock()
+		defer kpr.certMu.RUnlock()
+		return kpr.cert, nil
+	}
+}


### PR DESCRIPTION
For systems on which certbot or other LetsEncrypt setups are already deployed,
re-using the existing certificates might be more convenient to set up.

When receiving SIGHUP, the certificates are reloaded. Sending SIGHUP can be done
from the certbot deploy-hook, for example.